### PR TITLE
Add option to extend the core oauth_* parameters

### DIFF
--- a/lib/oauth-1.0a.js
+++ b/lib/oauth-1.0a.js
@@ -45,10 +45,11 @@ function OAuth(opts) {
     data
   }
   @param {Object} public and secret token
+  @param {Object} Additional oauth_* request parameters, if required
 
   @return {Object} OAuth Authorized data
 */
-OAuth.prototype.authorize = function(request, token) {
+OAuth.prototype.authorize = function(request, token, oauth_data_ext) {
   var oauth_data = {
     oauth_consumer_key: this.consumer.public,
     oauth_nonce: this.getNonce(),
@@ -56,6 +57,12 @@ OAuth.prototype.authorize = function(request, token) {
     oauth_timestamp: this.getTimeStamp(),
     oauth_version: '1.0'
   };
+
+  if (typeof oauth_data_ext == 'object') {
+    for (var i in oauth_data_ext) {
+      oauth_data[i] = oauth_data_ext[i];
+    }
+  }
 
   if(!token)
     token = {};


### PR DESCRIPTION
Just adding a method to inject additional oauth_\* parameters. For example, some services require a `oauth_callback` parameter.
