### PR TITLE
Allow timestamp correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ var oauth = OAuth({
 
 Get OAuth request data then you can use with your http client easily :)
 ```js
-oauth.authorize(request, token);
+oauth.authorize(request, token, [adjustSeconds]);
 ```
+If you know that the server and client times are not synchronized, you can pass in a number of seconds to adjust the signing timestamp.
+Positive adjustments will produce a future timestamp, in case the server's time is ahead of your client's.
+If you client's time is ahead of the server's, then use a negative adjustment.
 
 Or if you want to get as a header key-value data
 ```js

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ oauth.authorize(request, token, [adjustSeconds]);
 ```
 If you know that the server and client times are not synchronized, you can pass in a number of seconds to adjust the signing timestamp.
 Positive adjustments will produce a future timestamp, in case the server's time is ahead of your client's.
-If you client's time is ahead of the server's, then use a negative adjustment.
+If your client's time is ahead of the server's, then use a negative adjustment.
 
 Or if you want to get as a header key-value data
 ```js

--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -61,12 +61,12 @@ function OAuth(opts) {
  * @param  {Object} public and secret token
  * @return {Object} OAuth Authorized data
  */
-OAuth.prototype.authorize = function(request, token) {
+OAuth.prototype.authorize = function(request, token, adjustSeconds) {
     var oauth_data = {
         oauth_consumer_key: this.consumer.public,
         oauth_nonce: this.getNonce(),
         oauth_signature_method: this.signature_method,
-        oauth_timestamp: this.getTimeStamp(),
+        oauth_timestamp: this.getTimeStamp(adjustSeconds),
         oauth_version: this.version
     };
 
@@ -256,8 +256,8 @@ OAuth.prototype.getNonce = function() {
  * Get Current Unix TimeStamp
  * @return {Int} current unix timestamp
  */
-OAuth.prototype.getTimeStamp = function() {
-    return parseInt(new Date().getTime()/1000, 10);
+OAuth.prototype.getTimeStamp = function(adjustSeconds) {
+    return parseInt(new Date().getTime()/1000, 10) + (adjustSeconds || 0);
 };
 
 ////////////////////// HELPER FUNCTIONS //////////////////////

--- a/test/timestamp.js
+++ b/test/timestamp.js
@@ -1,0 +1,58 @@
+var expect;
+
+//Node.js
+if(typeof(module) !== 'undefined' && typeof(exports) !== 'undefined') {
+    expect = require('chai').expect;
+    var OAuth = require('../../oauth-1.0a');
+} else { //Browser
+    expect = chai.expect;
+}
+
+function unixtime() {
+	return Math.floor(new Date().getTime()/1000)
+}
+
+describe("timestamp adjustment argument", function() {
+   var oauth = OAuth({
+		consumer: {
+			public: 'xvz1evFS4wEEPTGEFPHBog',
+			secret: 'kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw'
+		},
+		signature_method: 'HMAC-SHA1'
+	});
+	var request = {
+		url: 'https://api.twitter.com/1/statuses/update.json?include_entities=true',
+		method: 'POST',
+		data: {
+			status: 'Hello Ladies + Gentlemen, a signed OAuth request!'
+		}
+	};
+	var token = {
+		public: '370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb',
+		secret: 'LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE'
+	};
+
+    describe("no adjustment", function() {
+		var now = unixtime()
+		var authorization = oauth.authorize(request, token)
+		it("produces a timestamp of now", function() {
+			expect(authorization.oauth_timestamp).to.equal(now)
+		});
+	});
+
+    describe("positive adjustment", function() {
+		var future = unixtime() + 55
+		var authorization = oauth.authorize(request, token, 55)
+		it("produces a timestamp in the future", function() {
+			expect(authorization.oauth_timestamp).to.equal(future)
+		});
+	});
+
+    describe("negative adjustment", function() {
+		var past = unixtime() - 44
+		var authorization = oauth.authorize(request, token, -44)
+		it("produces a timestamp in the past", function() {
+			expect(authorization.oauth_timestamp).to.equal(past)
+		});
+	});
+});


### PR DESCRIPTION
When I can programatically track the skew between client and server clocks, I find it useful to adjust the timestamp that oauth uses.  This modification allows passing a positive or negative number of seconds to adjust the client's timestamp.