### PR TITLE
Add HMAC-SHA256 support

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -38,6 +38,11 @@ function OAuth(opts) {
                 return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
             };
             break;
+        case 'HMAC-SHA256':
+            this.hash = function(base_string, key) {
+                return CryptoJS.HmacSHA256(base_string, key).toString(CryptoJS.enc.Base64);
+            };
+            break;
         case 'PLAINTEXT':
             this.hash = function(base_string, key) {
                 return key;


### PR DESCRIPTION
Simpy include http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/hmac-sha256.js to take advantage of the improved signing method.