### PR TITLE
Add support for generating known signature

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -72,9 +72,9 @@ function OAuth(opts) {
 OAuth.prototype.authorize = function(request, token) {
     var oauth_data = {
         oauth_consumer_key: this.consumer.public,
-        oauth_nonce: this.getNonce(),
+        oauth_nonce: request.nonce ? request.nonce : this.getNonce(),
         oauth_signature_method: this.signature_method,
-        oauth_timestamp: this.getTimeStamp(),
+        oauth_timestamp: request.timestamp ? request.timestamp : this.getTimeStamp(),
         oauth_version: this.version
     };
 


### PR DESCRIPTION
Update oauth-1.0a.js to support passing of nonce and timestamp to oauth.authorize. This allows the setting of all parameters required to generate a known signature for validation.