### PR TITLE
Correct handling of empty GET parameters

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -131,6 +131,10 @@ OAuth.prototype.getParameterString = function(request, oauth_data) {
 
     var data_str = '';
 
+    if(base_string_data.hasOwnProperty('') && (base_string_data[''] == undefined || base_string_data[''] == "undefined")){
+        base_string_data[''] = '';
+    }
+
     //base_string_data to string
     for(var key in base_string_data) {
         var value = base_string_data[key];


### PR DESCRIPTION
For example CouchDB parse a "?&" combination in URL as: {[],[]}. But oauth-1.0a.js putting into the parameter string something like this: {[],[undefined]}.

This combination of chars appears for example in PouchDB libary since version 5.1.0.