### PR TITLE
Bug fix to allow two-legged OAuth calls between servers

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -70,7 +70,7 @@ OAuth.prototype.authorize = function(request, token) {
         token = {};
     }
 
-    if(token.key) {
+    if(token.key !== undefined) {
         oauth_data.oauth_token = token.key;
     }
 


### PR DESCRIPTION
In order to make two-legged calls between servers I need the oauth_token value
to be an empty string.  Checking against 'undefined' accomplishes this.