### PR TITLE
Support for multiple duplicate keys in the QS of the url

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -207,7 +207,20 @@ OAuth.prototype.deParam = function(string) {
         // '' value
         item[1] = item[1] || '';
 
-        data[item[0]] = decodeURIComponent(item[1]);
+        // check if the key already exists
+        // this can occur if the QS part of the url contains duplicate keys like this: ?formkey=formvalue1&formkey=formvalue2
+        if (data[item[0]]){
+          // the key exists already
+          if (!Array.isArray(data[item[0]])) {
+            // replace the value with an array containing the already present value
+            data[item[0]] = [data[item[0]]];
+          }
+          // and add the new found value to it
+          data[item[0]].push(decodeURIComponent(item[1]));
+        } else {
+          // it doesn't exist, just put the found value in the data object
+          data[item[0]] = decodeURIComponent(item[1]);
+        }
     }
 
     return data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-1.0a",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "OAuth 1.0a Request Authorization for Node and Browser.",
   "scripts": {
     "test": "make test"

--- a/test/options/multiple_values_qs.js
+++ b/test/options/multiple_values_qs.js
@@ -36,7 +36,7 @@ describe("Signature method", function() {
         var result = oauth.authorize(request_data);
 
         it("Signature should match", function() {
-            expect(result.oauth_signature).to.equal("b6nMehqpHnpx0VlZB9IhqFh4Jq0%3D");
+            expect(result.oauth_signature).to.equal("b6nMehqpHnpx0VlZB9IhqFh4Jq0=");
         });
 
         it("Nonce should match", function() {

--- a/test/options/multiple_values_qs.js
+++ b/test/options/multiple_values_qs.js
@@ -1,0 +1,50 @@
+var expect = require('chai').expect;
+var OAuth = require('../../oauth-1.0a');
+var crypto = require('crypto');
+
+function hash_function_SHA1(base_string, key) {
+    return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+}
+
+describe("Signature method", function() {
+    describe("HMAC-SHA1 signature method with multiple duplicate values in the querystring", function() {
+        var oauth = new OAuth({
+            consumer: {
+            key: "batch-8f4fd2c6-9fa3-4368-9797-52876d723dd1",
+            secret: "ZACXtYe6LQ4C5X0KbJcDkbW77GYtlaoU"
+            },
+            signature_method: 'HMAC-SHA1',
+            hash_function: hash_function_SHA1
+        });
+
+        //overide for testing only !!!
+        oauth.getTimeStamp = function() {
+            return 1504882975;
+        };
+
+        //overide for testing only !!!
+        oauth.getNonce = function(length) {
+            return 'xsEYfvjTEiPTR3TqJbmhCpUdrDoHF6nk';
+        };
+
+
+        var request_data = {
+          url: "http://localhost:3737/rest/profiles?property=email&value=vel.arcu%40ultriciesornareelit.ca&property=visitdate&value=abc&alt=json",
+          method: "GET"
+        };
+
+        var result = oauth.authorize(request_data);
+
+        it("Signature should match", function() {
+            expect(result.oauth_signature).to.equal("b6nMehqpHnpx0VlZB9IhqFh4Jq0%3D");
+        });
+
+        it("Nonce should match", function() {
+            expect(result.oauth_nonce).to.equal("xsEYfvjTEiPTR3TqJbmhCpUdrDoHF6nk");
+        });
+
+        it("Timestamp should match", function() {
+            expect(result.oauth_timestamp).to.equal(1504882975);
+        });
+    });
+});


### PR DESCRIPTION
Earlier i fixed https://github.com/ddo/oauth-1.0a/pull/28, which adds support for multiple values in the data parameter (the body of the request).

This pull request adds support for multiple duplicate keys in the QS of the url.
For example: 

?formkey=formvalue1&formkey=formvalue2

This couldn't be signed properly earlier, and with this pull request, it can :)
Added unit test which tests this specific behavior.