### PR TITLE
makes e2e tests optionals and ease their setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
-test:
-	mocha --recursive --reporter spec --slow 1
-	
-coveralls:
-	istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 
-.PHONY: test
+test: node_modules
+	npm test
+
+coverage: coverage/lcov.info
+	node_modules/.bin/istanbul report text
+
+coveralls: coverage/lcov.info
+	cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+
+.PHONY: test coverage coveralls
+
+coverage/lcov.info: node_modules package.json oauth-1.0a.js test/*.js test/**/*.js test/mocha.opts
+	node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly
+
+node_modules: package.json
+	npm install
+	touch node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-test: node_modules
+test: node_modules .env
 	npm test
 
 coverage: coverage/lcov.info
@@ -10,7 +10,25 @@ coveralls: coverage/lcov.info
 
 .PHONY: test coverage coveralls
 
-coverage/lcov.info: node_modules package.json oauth-1.0a.js test/*.js test/**/*.js test/mocha.opts
+.env:
+	@echo "BITBUCKET_CONSUMER_PUBLIC=" > $@
+	@echo "BITBUCKET_CONSUMER_SECRET=" >> $@
+	@echo "" >> $@
+	@echo "FLICKR_CONSUMER_key=" >> $@
+	@echo "FLICKR_CONSUMER_SECRET=" >> $@
+	@echo "" >> $@
+	@echo "LINKEDIN_CONSUMER_PUBLIC=" >> $@
+	@echo "LINKEDIN_CONSUMER_SECRET=" >> $@
+	@echo "" >> $@
+	@echo "OPENBANK_CONSUMER_PUBLIC=" >> $@
+	@echo "OPENBANK_CONSUMER_SECRET=" >> $@
+	@echo "" >> $@
+	@echo "TWITTER_CONSUMER_PUBLIC=" >> $@
+	@echo "TWITTER_CONSUMER_SECRET=" >> $@
+	@echo "TWITTER_TOKEN_PUBLIC=" >> $@
+	@echo "TWITTER_TOKEN_SECRET=" >> $@
+
+coverage/lcov.info: node_modules package.json oauth-1.0a.js .env test/*.js test/**/*.js test/mocha.opts
 	node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly
 
 node_modules: package.json

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
+    "dotenv": "^4.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",
     "request": "~2.33.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.3",
   "description": "OAuth 1.0a Request Authorization for Node and Browser.",
   "scripts": {
-    "test": "make test"
+    "test": "mocha"
   },
   "main": "oauth-1.0a.js",
   "types": "oauth-1.0a.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Ddo",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "~1.17.0",
-    "chai": "~1.8.1",
-    "request": "~2.33.0",
-    "istanbul": "^0.2.7",
-    "coveralls": "^2.10.0"
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^4.0.1",
+    "request": "~2.33.0"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --recursive
 --reporter spec
+--require dotenv/config
 --slow 1

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--reporter spec
+--slow 1

--- a/test/services/bitbucket.js
+++ b/test/services/bitbucket.js
@@ -4,17 +4,29 @@ var OAuth   = require('../../oauth-1.0a');
 var crypto = require('crypto');
 
 describe("Bitbucket Personal Consumer", function() {
-    this.timeout(10000);
+    var oauth
 
-    var oauth = new OAuth({
-        consumer: {
-            key: process.env.BITBUCKET_CONSUMER_PUBLIC,
-            secret: process.env.BITBUCKET_CONSUMER_SECRET
-        },
-        signature_method: 'HMAC-SHA1',
-        hash_function: function(base_string, key) {
-            return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+    beforeEach(function () {
+        if (
+            !process.env.BITBUCKET_CONSUMER_PUBLIC ||
+            !process.env.BITBUCKET_CONSUMER_SECRET
+        ) {
+            this.skip('Bitbucket secret not set.');
+            return;
         }
+
+        this.timeout(10000);
+
+        oauth = new OAuth({
+            consumer: {
+                key: process.env.BITBUCKET_CONSUMER_PUBLIC,
+                secret: process.env.BITBUCKET_CONSUMER_SECRET
+            },
+            signature_method: 'HMAC-SHA1',
+            hash_function: function(base_string, key) {
+                return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+            }
+        });
     });
 
     describe("#Request Token", function() {

--- a/test/services/flickr.js
+++ b/test/services/flickr.js
@@ -4,17 +4,29 @@ var OAuth   = require('../../oauth-1.0a');
 var crypto = require('crypto');
 
 describe("Flickr Personal Consumer", function() {
-    this.timeout(10000);
+    var oauth;
 
-    var oauth = new OAuth({
-        consumer: {
-            key: process.env.FLICKR_CONSUMER_key,
-            secret: process.env.FLICKR_CONSUMER_SECRET
-        },
-        signature_method: 'HMAC-SHA1',
-        hash_function: function(base_string, key) {
-            return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+    beforeEach(function () {
+        if (
+            !process.env.FLICKR_CONSUMER_key ||
+            !process.env.FLICKR_CONSUMER_SECRET
+        ) {
+            this.skip('Flickr secret not set.');
+            return;
         }
+
+        this.timeout(10000);
+
+        oauth = new OAuth({
+            consumer: {
+                key: process.env.FLICKR_CONSUMER_key,
+                secret: process.env.FLICKR_CONSUMER_SECRET
+            },
+            signature_method: 'HMAC-SHA1',
+            hash_function: function(base_string, key) {
+                return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+            }
+        });
     });
 
     describe.skip("#Request Token", function() {

--- a/test/services/linkedin.js
+++ b/test/services/linkedin.js
@@ -7,17 +7,29 @@ var crypto = require('crypto');
     Can not use Header
 */
 describe("Linkedin Personal Consumer", function() {
-    this.timeout(10000);
+    var oauth;
 
-    var oauth = new OAuth({
-        consumer: {
-            key: process.env.LINKEDIN_CONSUMER_PUBLIC,
-            secret: process.env.LINKEDIN_CONSUMER_SECRET
-        },
-        signature_method: 'HMAC-SHA1',
-        hash_function: function(base_string, key) {
-            return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+    beforeEach(function () {
+        if (
+            !process.env.LINKEDIN_CONSUMER_PUBLIC ||
+            !process.env.LINKEDIN_CONSUMER_SECRET
+        ) {
+            this.skip('LinkedIn secret not set.');
+            return;
         }
+
+        this.timeout(10000);
+
+        oauth = new OAuth({
+            consumer: {
+                key: process.env.LINKEDIN_CONSUMER_PUBLIC,
+                secret: process.env.LINKEDIN_CONSUMER_SECRET
+            },
+            signature_method: 'HMAC-SHA1',
+            hash_function: function(base_string, key) {
+                return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+            }
+        });
     });
 
     describe("#Request Token", function() {

--- a/test/services/openbank.js
+++ b/test/services/openbank.js
@@ -4,17 +4,29 @@ var OAuth   = require('../../oauth-1.0a');
 var crypto = require('crypto');
 
 describe.skip("Openbank Personal Consumer", function() {
-    this.timeout(10000);
+    var oauth;
 
-    var oauth = new OAuth({
-        consumer: {
-            key: process.env.OPENBANK_CONSUMER_PUBLIC,
-            secret: process.env.OPENBANK_CONSUMER_SECRET
-        },
-        signature_method: 'HMAC-SHA256',
-        hash_function: function(base_string, key) {
-            return crypto.createHmac('sha256', key).update(base_string).digest('base64');
+    beforeEach(function () {
+        if (
+            !process.env.OPENBANK_CONSUMER_PUBLIC ||
+            !process.env.OPENBANK_CONSUMER_SECRET
+        ) {
+            this.skip('Openbank secret not set.');
+            return;
         }
+
+        this.timeout(10000);
+
+        oauth = new OAuth({
+            consumer: {
+                key: process.env.OPENBANK_CONSUMER_PUBLIC,
+                secret: process.env.OPENBANK_CONSUMER_SECRET
+            },
+            signature_method: 'HMAC-SHA256',
+            hash_function: function(base_string, key) {
+                return crypto.createHmac('sha256', key).update(base_string).digest('base64');
+            }
+        });
     });
 
     //need to send as header

--- a/test/services/twitter.js
+++ b/test/services/twitter.js
@@ -4,25 +4,39 @@ var OAuth   = require('../../oauth-1.0a');
 var crypto = require('crypto');
 
 describe("Twitter Personal Consumer", function() {
-    var oauth = new OAuth({
-        consumer: {
-            key: process.env.TWITTER_CONSUMER_PUBLIC,
-            secret: process.env.TWITTER_CONSUMER_SECRET
-        },
-        signature_method: 'HMAC-SHA1',
-        hash_function: function(base_string, key) {
-            return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+    var oauth, token;
+
+    beforeEach(function () {
+        if (
+            !process.env.TWITTER_CONSUMER_PUBLIC ||
+            !process.env.TWITTER_CONSUMER_SECRET ||
+            !process.env.TWITTER_TOKEN_PUBLIC ||
+            !process.env.TWITTER_TOKEN_SECRET
+        ) {
+            this.skip('Twitter secret or token not set.');
+            return;
         }
-    });
 
-    var token = {
-        key: process.env.TWITTER_TOKEN_PUBLIC,
-        secret: process.env.TWITTER_TOKEN_SECRET
-    };
-
-    describe("#Get user timeline", function() {
         this.timeout(10000);
 
+        oauth = new OAuth({
+            consumer: {
+                key: process.env.TWITTER_CONSUMER_PUBLIC,
+                secret: process.env.TWITTER_CONSUMER_SECRET
+            },
+            signature_method: 'HMAC-SHA1',
+            hash_function: function(base_string, key) {
+                return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+            }
+        });
+
+        token = {
+            key: process.env.TWITTER_TOKEN_PUBLIC,
+            secret: process.env.TWITTER_TOKEN_SECRET
+        };
+    });
+
+    describe("#Get user timeline", function() {
         var request = {
             url: 'https://api.twitter.com/1.1/statuses/user_timeline.json',
             method: 'GET'
@@ -43,8 +57,6 @@ describe("Twitter Personal Consumer", function() {
     });
 
     describe("#Get user timeline limit 5", function() {
-        this.timeout(10000);
-
         var request = {
             url: 'https://api.twitter.com/1.1/statuses/user_timeline.json',
             method: 'GET',
@@ -69,8 +81,6 @@ describe("Twitter Personal Consumer", function() {
     });
 
     describe("#Get user timeline limit 5 by url", function() {
-        this.timeout(10000);
-
         var request = {
             url: 'https://api.twitter.com/1.1/statuses/user_timeline.json?count=5',
             method: 'GET'
@@ -92,8 +102,6 @@ describe("Twitter Personal Consumer", function() {
     });
 
     describe("#Get user timeline by header", function() {
-        this.timeout(10000);
-
         var request = {
             url: 'https://api.twitter.com/1.1/statuses/user_timeline.json',
             method: 'GET'
@@ -115,8 +123,6 @@ describe("Twitter Personal Consumer", function() {
     });
 
     describe.skip("#Tweet", function() {
-        this.timeout(10000);
-
         var text = 'Testing oauth-1.0a';
 
         var request = {
@@ -146,8 +152,6 @@ describe("Twitter Personal Consumer", function() {
     });
 
     describe.skip("#Tweet by header", function() {
-        this.timeout(10000);
-
         var text = 'Testing oauth-1.0a';
 
         var request = {


### PR DESCRIPTION
- [x] Skip tests requiring missing environment variable.
- [x] Support dotenv to manage tests' environment variable.
- [x] refactor npm run test to not require `make`.
- [x] add coverage task (text report).
- [x] refactor makefile (only rerun test if necessary before running coverage, move mocha config to `opts.mocha`).

Each e2e tests are skipped unless the consumer keys/secret they require are set (as environment variable).

`make .env` create a ".env" with the environment variables required by those tests; they will be loaded into `process.env` by mocha. You still need to go register an app with each services but it's easier to load them into env.

Note that variables set in ".env" should not override env variables already set.
  