### PR TITLE
Add a whitelist in options for header parameters that do not begin with oauth_

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -24,6 +24,7 @@ function OAuth(opts) {
     this.version             = opts.version || '1.0';
     this.parameter_seperator = opts.parameter_seperator || ', ';
     this.realm               = opts.realm;
+    this.headerWhitelist     = opts.headerWhitelist || [];
 
     if(typeof opts.last_ampersand === 'undefined') {
         this.last_ampersand = true;
@@ -301,7 +302,7 @@ OAuth.prototype.toHeader = function(oauth_data) {
     }
 
     for(var i = 0; i < sorted.length; i++) {
-        if (sorted[i].key.indexOf('oauth_') !== 0)
+        if (sorted[i].key.indexOf('oauth_') !== 0 && !this.headerWhitelist.includes(sorted[i].key))
             continue;
 
         header_value += this.percentEncode(sorted[i].key) + '="' + this.percentEncode(sorted[i].value) + '"' + this.parameter_seperator;


### PR DESCRIPTION
Right now the toHeader() function will strip away all parameters that don't begin with "oauth_", I have added a white list option to deal with cases where there are non-standard headers such as xoauth that is required in the Authorization string.