### PR TITLE
Remove empty keys

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -148,6 +148,11 @@ OAuth.prototype.getParameterString = function(request, oauth_data) {
     for(var i = 0; i < base_string_data.length; i++) {
         var key = base_string_data[i].key;
         var value = base_string_data[i].value;
+
+        // skip empty keys
+        if (key === '') {
+            continue;
+        }
         // check if the value is an array
         // this means that this key has multiple values
         if (value && Array.isArray(value)){


### PR DESCRIPTION
I was using this package for to handle oauth and making rest api requests to magento. In the filters to the endpoint I had a trailing `&` which made the request fail, so thought it would be a good idea to actually remove all empty parameters.