### PR TITLE
Add oauth_validation support for user access token requests

### DIFF
--- a/oauth-1.0a.d.ts
+++ b/oauth-1.0a.d.ts
@@ -135,6 +135,7 @@ declare namespace OAuth {
     oauth_version: string;
     oauth_token?: string;
     oauth_body_hash?: string;
+    oauth_verifier?: string;
   }
 
   /**

--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -59,7 +59,7 @@ function OAuth(opts) {
  * @param  {Object} key and secret token
  * @return {Object} OAuth Authorized data
  */
-OAuth.prototype.authorize = function(request, token) {
+OAuth.prototype.authorize = function(request, token, verifier) {
     var oauth_data = {
         oauth_consumer_key: this.consumer.key,
         oauth_nonce: this.getNonce(),
@@ -82,6 +82,10 @@ OAuth.prototype.authorize = function(request, token) {
 
     if(request.includeBodyHash) {
       oauth_data.oauth_body_hash = this.getBodyHash(request, token.secret)
+    }
+
+    if(verifier) {
+      oauth_data.oauth_verifier = verifier;
     }
 
     oauth_data.oauth_signature = this.getSignature(request, token.secret, oauth_data);


### PR DESCRIPTION
The [OAuth 1.0a specification](https://oauth.net/core/1.0a/) provides for a field <oauth_verifier> to be included in the signature body and sent in the Authorization header. This PR adds support for this field. It is needed for the Garmin Connect API and perhaps others.