### PR TITLE
fix typo. signature_metho => signature_method

### DIFF
--- a/oauth-1.0a.d.ts
+++ b/oauth-1.0a.d.ts
@@ -14,7 +14,7 @@ declare class OAuth {
   nonce_length: number;
   parameter_seperator: string;
   realm: string;
-  signature_metho: string;
+  signature_method: string;
   version: string;
 
   constructor(opts?: OAuth.Options);


### PR DESCRIPTION
Fix typo of property name in `declare class OAuth` for `.d.ts`

```  javascript
- 17 signature_metho: string;
+ 17 signature_method: string;
```