### PR TITLE
Add authorize async function for asynchronous signature functions

### DIFF
--- a/oauth-1.0a.js
+++ b/oauth-1.0a.js
@@ -89,6 +89,22 @@ OAuth.prototype.authorize = function(request, token) {
     return oauth_data;
 };
 
+OAuth.prototype.authorizeAsync = function(request, token) {
+    return new Promise((resolve, reject) => {
+        var { oauth_signature: _discard, ...oauth_data_sync } = this.authorize(request, token);
+
+        this.getSignature(request, token.secret, oauth_data_sync)
+            .then((oauth_signature) => {
+                var oauth_data = {
+                    ...oauth_data_sync,
+                    oauth_signature,
+                };
+
+              resolve(oauth_data);
+            });
+    })
+}
+
 /**
  * Create a OAuth Signature
  * @param  {Object} request data


### PR DESCRIPTION
Hi, I’m proposing adding a new `authorizeAsync` function, which helps for people who want to use the WebCrypto APIs, which are synchronous, i.e.

```js
const hmacSha256Base64Digest = async (body, k) => {
  const secret = k;
  const enc = new TextEncoder('utf-8');
  const algorithm = { name: 'HMAC', hash: 'SHA-256' };

  const key = await crypto.subtle.importKey('raw', enc.encode(secret), algorithm, false, ['sign', 'verify']);
  const signature = await crypto.subtle.sign(algorithm.name, key, enc.encode(body));
  const digest = btoa(String.fromCharCode(...new Uint8Array(signature)));

  return digest;
}
```

```js
 const oauthAuthorized = await oauth.authorizeAsync(request_data, { key: 'asdf', secret: 'qwerty' })
```

> Ref #108 
